### PR TITLE
feat(ui): implement Articles and Home screens

### DIFF
--- a/shared/src/commonMain/kotlin/com/lumen/core/memory/SemanticCompressor.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/core/memory/SemanticCompressor.kt
@@ -1,5 +1,6 @@
 package com.lumen.core.memory
 
+import com.lumen.core.util.formatEpochDate
 import kotlinx.serialization.json.Json
 
 class SemanticCompressor(private val llmCall: LlmCall) {
@@ -13,7 +14,7 @@ class SemanticCompressor(private val llmCall: LlmCall) {
     }
 
     internal fun buildSystemPrompt(currentTime: Long): String {
-        val currentDate = formatDate(currentTime)
+        val currentDate = formatEpochDate(currentTime)
         return """
 You are a memory extraction assistant. Your task is to extract atomic, self-contained facts from a conversation.
 
@@ -62,37 +63,4 @@ If no meaningful facts can be extracted, return an empty array: []
         return text.substring(start, end + 1)
     }
 
-    private fun formatDate(timeMillis: Long): String {
-        val totalDays = timeMillis / 86_400_000L
-        // Unix epoch is 1970-01-01 (Thursday)
-        var year = 1970
-        var remaining = totalDays
-
-        while (true) {
-            val daysInYear = if (isLeapYear(year)) 366L else 365L
-            if (remaining < daysInYear) break
-            remaining -= daysInYear
-            year++
-        }
-
-        val monthDays = if (isLeapYear(year)) {
-            intArrayOf(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
-        } else {
-            intArrayOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
-        }
-
-        var month = 1
-        for (days in monthDays) {
-            if (remaining < days) break
-            remaining -= days
-            month++
-        }
-        val day = remaining.toInt() + 1
-
-        return "$year-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}"
-    }
-
-    private fun isLeapYear(year: Int): Boolean {
-        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
-    }
 }

--- a/shared/src/commonMain/kotlin/com/lumen/core/util/DateUtils.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/core/util/DateUtils.kt
@@ -1,0 +1,59 @@
+package com.lumen.core.util
+
+fun formatEpochDate(epochMillis: Long): String {
+    val totalDays = epochMillis / 86_400_000L
+    var remainingDays = totalDays
+    var year = 1970
+    while (true) {
+        val daysInYear = if (isLeapYear(year)) 366L else 365L
+        if (remainingDays < daysInYear) break
+        remainingDays -= daysInYear
+        year++
+    }
+    val monthDays = if (isLeapYear(year)) {
+        intArrayOf(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    } else {
+        intArrayOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    }
+    var month = 1
+    for (m in monthDays) {
+        if (remainingDays < m) break
+        remainingDays -= m
+        month++
+    }
+    val day = remainingDays.toInt() + 1
+    return "${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}"
+}
+
+fun dateToEpochRange(date: String): Pair<Long, Long> {
+    val parts = date.split("-")
+    if (parts.size != 3) return 0L to 0L
+    val year = parts[0].toIntOrNull() ?: return 0L to 0L
+    val month = parts[1].toIntOrNull() ?: return 0L to 0L
+    val day = parts[2].toIntOrNull() ?: return 0L to 0L
+
+    val startOfDay = dateToEpochMillis(year, month, day)
+    val endOfDay = startOfDay + 86_400_000L
+    return startOfDay to endOfDay
+}
+
+private fun dateToEpochMillis(year: Int, month: Int, day: Int): Long {
+    var totalDays = 0L
+    for (y in 1970 until year) {
+        totalDays += if (isLeapYear(y)) 366 else 365
+    }
+    val monthDays = if (isLeapYear(year)) {
+        intArrayOf(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    } else {
+        intArrayOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    }
+    for (m in 1 until month) {
+        totalDays += monthDays[m - 1]
+    }
+    totalDays += day - 1
+    return totalDays * 86_400_000L
+}
+
+fun isLeapYear(year: Int): Boolean {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}

--- a/shared/src/commonMain/kotlin/com/lumen/research/digest/DigestGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/research/digest/DigestGenerator.kt
@@ -5,6 +5,7 @@ import com.lumen.core.database.entities.Article
 import com.lumen.core.database.entities.Digest
 import com.lumen.core.memory.LlmCall
 import com.lumen.core.memory.MemoryManager
+import com.lumen.core.util.dateToEpochRange
 import com.lumen.research.parseCsvSet
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -188,38 +189,5 @@ class DigestGenerator(
 Return a JSON object only, with no other text:
 
 {"title": "Digest title", "highlights": "Multi-paragraph highlights text", "trends": "Trend analysis text"}"""
-
-        internal fun dateToEpochRange(date: String): Pair<Long, Long> {
-            val parts = date.split("-")
-            if (parts.size != 3) return 0L to 0L
-            val year = parts[0].toIntOrNull() ?: return 0L to 0L
-            val month = parts[1].toIntOrNull() ?: return 0L to 0L
-            val day = parts[2].toIntOrNull() ?: return 0L to 0L
-
-            val startOfDay = dateToEpochMillis(year, month, day)
-            val endOfDay = startOfDay + 86_400_000L
-            return startOfDay to endOfDay
-        }
-
-        private fun dateToEpochMillis(year: Int, month: Int, day: Int): Long {
-            var totalDays = 0L
-            for (y in 1970 until year) {
-                totalDays += if (isLeapYear(y)) 366 else 365
-            }
-            val monthDays = if (isLeapYear(year)) {
-                intArrayOf(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
-            } else {
-                intArrayOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
-            }
-            for (m in 1 until month) {
-                totalDays += monthDays[m - 1]
-            }
-            totalDays += day - 1
-            return totalDays * 86_400_000L
-        }
-
-        private fun isLeapYear(year: Int): Boolean {
-            return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
-        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/lumen/ui/screen/ArticlesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/ui/screen/ArticlesScreen.kt
@@ -55,12 +55,14 @@ import com.lumen.core.database.LumenDatabase
 import com.lumen.core.database.entities.Article
 import com.lumen.core.database.entities.ResearchProject
 import com.lumen.core.memory.MemoryManager
+import com.lumen.core.util.formatEpochDate
 import com.lumen.research.ProjectManager
 import com.lumen.research.collector.RssCollector
 import com.lumen.research.parseCsvSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.koin.compose.getKoin
 import org.koin.compose.koinInject
 
 private enum class SortMode(val label: String) {
@@ -74,7 +76,7 @@ fun ArticlesScreen() {
     val db = koinInject<LumenDatabase>()
     val projectManager = koinInject<ProjectManager>()
     val rssCollector = koinInject<RssCollector>()
-    val memoryManager = org.koin.compose.getKoin().getOrNull<MemoryManager>()
+    val memoryManager = getKoin().getOrNull<MemoryManager>()
 
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -89,11 +91,15 @@ fun ArticlesScreen() {
     var selectedArticle by remember { mutableStateOf<Article?>(null) }
     var projectExpanded by remember { mutableStateOf(false) }
 
+    // Initialize activeProjectId from DB once on first composition
+    LaunchedEffect(Unit) {
+        val activeProject = projectManager.getActive()
+        activeProjectId = activeProject?.id ?: 0L
+    }
+
     fun loadData() {
         sourceNames = db.sourceBox.all.associate { it.id to it.name }
         projects = projectManager.listAll()
-        val activeProject = projectManager.getActive()
-        activeProjectId = activeProject?.id ?: 0L
 
         val allArticles = db.articleBox.all
         val filtered = allArticles
@@ -469,31 +475,3 @@ private fun ArticleDetailDialog(
     )
 }
 
-internal fun formatEpochDate(epochMillis: Long): String {
-    val totalDays = epochMillis / 86_400_000L
-    var remainingDays = totalDays
-    var year = 1970
-    while (true) {
-        val daysInYear = if (isLeapYear(year)) 366L else 365L
-        if (remainingDays < daysInYear) break
-        remainingDays -= daysInYear
-        year++
-    }
-    val monthDays = if (isLeapYear(year)) {
-        intArrayOf(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
-    } else {
-        intArrayOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
-    }
-    var month = 1
-    for (m in monthDays) {
-        if (remainingDays < m) break
-        remainingDays -= m
-        month++
-    }
-    val day = remainingDays.toInt() + 1
-    return "${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}"
-}
-
-private fun isLeapYear(year: Int): Boolean {
-    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
-}

--- a/shared/src/commonMain/kotlin/com/lumen/ui/screen/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/ui/screen/HomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.lumen.core.database.LumenDatabase
 import com.lumen.core.database.entities.Digest
+import com.lumen.core.util.formatEpochDate
 import com.lumen.research.digest.DigestFormatter
 import org.koin.compose.koinInject
 

--- a/shared/src/jvmTest/kotlin/com/lumen/research/digest/DigestGeneratorTest.kt
+++ b/shared/src/jvmTest/kotlin/com/lumen/research/digest/DigestGeneratorTest.kt
@@ -10,6 +10,7 @@ import com.lumen.core.memory.LlmCall
 import com.lumen.core.memory.MemoryManager
 import com.lumen.core.memory.SemanticCompressor
 import com.lumen.core.memory.SemanticSynthesizer
+import com.lumen.core.util.dateToEpochRange
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import kotlin.test.AfterTest
@@ -39,7 +40,7 @@ class DigestGeneratorTest {
     }
 
     private val testDate = "2026-03-07"
-    private val testDateStartEpoch = DigestGenerator.dateToEpochRange(testDate).first
+    private val testDateStartEpoch = dateToEpochRange(testDate).first
 
     @BeforeTest
     fun setup() {
@@ -224,11 +225,11 @@ class DigestGeneratorTest {
 
     @Test
     fun dateToEpochRange_correctBounds() {
-        val (start, end) = DigestGenerator.dateToEpochRange("2026-03-07")
+        val (start, end) = dateToEpochRange("2026-03-07")
         assertEquals(86_400_000L, end - start)
         assertTrue(start > 0)
 
-        val (invalidStart, invalidEnd) = DigestGenerator.dateToEpochRange("invalid")
+        val (invalidStart, invalidEnd) = dateToEpochRange("invalid")
         assertEquals(0L, invalidStart)
         assertEquals(0L, invalidEnd)
     }


### PR DESCRIPTION
## Description

Replace placeholder ArticlesScreen and HomeScreen with full implementations. ArticlesScreen provides article browsing with filtering, sorting, detail view, star/bookmark with M1 memory integration, project switching, and manual RSS refresh. HomeScreen shows today's digest summary card and quick stats.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

- Closes #33

## Change List

- [x] ArticlesScreen: article list with LazyColumn, source name display, relevance score, date
- [x] Article detail dialog: title, source, date, AI summary, relevance, keywords, URL
- [x] Star/bookmark: toggle starred, store article facts to MemoryManager (category=research_interest)
- [x] Project selector: ExposedDropdownMenuBox with All + project names, calls ProjectManager.setActive()
- [x] Sort toggle: switch between date and relevance sorting
- [x] Starred filter: toggle to show only starred articles
- [x] Manual refresh FAB: triggers RssCollector.fetchAll() with loading indicator and snackbar feedback
- [x] HomeScreen: welcome header, today's date, article/source count stat cards
- [x] HomeScreen: today's digest summary card using DigestFormatter.formatCompact()
- [x] KMP-compatible epoch-to-date formatting (no java.time imports in commonMain)

## Additional Notes

- Navigation already set up: Tab.Articles exists in enum, TabContent routes to ArticlesScreen()
- No new test files needed (Compose UI screens without test framework setup)
- All existing tests pass (shared:jvmTest + shared-db:test)