### PR TITLE
fix(research): address M2 bugs and code quality issues

### DIFF
--- a/shared-db/objectbox-models/default.json
+++ b/shared-db/objectbox-models/default.json
@@ -198,7 +198,9 @@
         {
           "id": "9:6675773818185487617",
           "name": "fetchedAt",
-          "type": 6
+          "indexId": "9:233493341227495940",
+          "type": 6,
+          "flags": 8
         },
         {
           "id": "10:9140870730389160215",
@@ -281,7 +283,9 @@
         {
           "id": "7:5283064180091067881",
           "name": "createdAt",
-          "type": 6
+          "indexId": "10:7485888030327260848",
+          "type": 6,
+          "flags": 8
         }
       ],
       "relations": []
@@ -341,7 +345,7 @@
     }
   ],
   "lastEntityId": "5:6135864324703906304",
-  "lastIndexId": "8:4748608305065077273",
+  "lastIndexId": "10:7485888030327260848",
   "lastRelationId": "0:0",
   "lastSequenceId": "0:0",
   "modelVersion": 5,

--- a/shared-db/src/main/kotlin/com/lumen/core/database/entities/Article.kt
+++ b/shared-db/src/main/kotlin/com/lumen/core/database/entities/Article.kt
@@ -15,7 +15,7 @@ data class Article(
     var content: String = "",
     var author: String = "",
     var publishedAt: Long = 0,
-    var fetchedAt: Long = 0,
+    @Index var fetchedAt: Long = 0,
     var readAt: Long = 0,
     var starred: Boolean = false,
     @HnswIndex(dimensions = HNSW_DIMENSIONS)

--- a/shared-db/src/main/kotlin/com/lumen/core/database/entities/Digest.kt
+++ b/shared-db/src/main/kotlin/com/lumen/core/database/entities/Digest.kt
@@ -12,5 +12,5 @@ data class Digest(
     var content: String = "",
     var sourceBreakdown: String = "",
     var projectId: Long = 0,
-    var createdAt: Long = 0
+    @Index var createdAt: Long = 0
 )

--- a/shared/src/commonMain/kotlin/com/lumen/companion/agent/LumenAgent.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/companion/agent/LumenAgent.kt
@@ -16,6 +16,7 @@ import com.lumen.core.database.LumenDatabase
 import com.lumen.core.memory.EmbeddingClient
 import com.lumen.core.memory.MemoryManager
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 
 class LumenAgent(
     private val config: LlmConfig,
@@ -24,7 +25,13 @@ class LumenAgent(
     private val embeddingClient: EmbeddingClient? = null,
 ) {
 
-    private val httpClient = HttpClient()
+    private val httpClient = HttpClient {
+        install(HttpTimeout) {
+            connectTimeoutMillis = CONNECT_TIMEOUT_MS
+            requestTimeoutMillis = REQUEST_TIMEOUT_MS
+            socketTimeoutMillis = REQUEST_TIMEOUT_MS
+        }
+    }
     private val llmClient: LLMClient = LlmClientFactory.createClient(config, httpClient)
     private val model = LlmClientFactory.resolveModel(config)
 
@@ -129,5 +136,7 @@ Use these tools when contextually appropriate."""
 
     private companion object {
         private const val MAX_TOOL_ITERATIONS = 5
+        private const val CONNECT_TIMEOUT_MS = 30_000L
+        private const val REQUEST_TIMEOUT_MS = 120_000L
     }
 }

--- a/shared/src/commonMain/kotlin/com/lumen/companion/agent/tools/GetDigestTool.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/companion/agent/tools/GetDigestTool.kt
@@ -2,6 +2,8 @@ package com.lumen.companion.agent.tools
 
 import ai.koog.agents.core.tools.SimpleTool
 import com.lumen.core.database.LumenDatabase
+import com.lumen.core.database.entities.Digest_
+import io.objectbox.query.QueryBuilder
 import com.lumen.core.util.formatEpochDate
 import kotlinx.serialization.Serializable
 
@@ -19,7 +21,10 @@ class GetDigestTool(
 ) {
     override suspend fun execute(args: GetDigestArgs): String {
         val targetDate = args.date.ifBlank { formatEpochDate(System.currentTimeMillis()) }
-        val digest = db.digestBox.all.firstOrNull { it.date == targetDate }
+        val digest = db.digestBox.query()
+            .equal(Digest_.date, targetDate, QueryBuilder.StringOrder.CASE_SENSITIVE)
+            .build()
+            .use { it.findFirst() }
             ?: return "No digest found for $targetDate."
 
         return buildString {

--- a/shared/src/commonMain/kotlin/com/lumen/companion/agent/tools/GetTrendsTool.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/companion/agent/tools/GetTrendsTool.kt
@@ -2,6 +2,7 @@ package com.lumen.companion.agent.tools
 
 import ai.koog.agents.core.tools.SimpleTool
 import com.lumen.core.database.LumenDatabase
+import com.lumen.core.database.entities.Digest_
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -18,9 +19,11 @@ class GetTrendsTool(
 ) {
     override suspend fun execute(args: GetTrendsArgs): String {
         val cutoff = System.currentTimeMillis() - args.days.coerceAtLeast(1) * 86_400_000L
-        val recentDigests = db.digestBox.all
-            .filter { it.createdAt >= cutoff }
-            .sortedByDescending { it.createdAt }
+        val recentDigests = db.digestBox.query()
+            .greaterOrEqual(Digest_.createdAt, cutoff)
+            .order(Digest_.createdAt, io.objectbox.query.QueryBuilder.DESCENDING)
+            .build()
+            .use { it.find() }
 
         if (recentDigests.isEmpty()) {
             return "No digests found in the last ${args.days} day(s)."

--- a/shared/src/commonMain/kotlin/com/lumen/core/di/Modules.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/core/di/Modules.kt
@@ -20,6 +20,7 @@ import com.lumen.research.collector.SourceManager
 import com.lumen.research.digest.DigestFormatter
 import com.lumen.research.digest.DigestGenerator
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -36,7 +37,13 @@ val companionModule = module {
 val memoryModule = module {
     factory<LlmCall> {
         val config = get<ConfigStore>().load().llm
-        val httpClient = HttpClient()
+        val httpClient = HttpClient {
+            install(HttpTimeout) {
+                connectTimeoutMillis = 30_000
+                requestTimeoutMillis = 120_000
+                socketTimeoutMillis = 120_000
+            }
+        }
         val client = LlmClientFactory.createClient(config, httpClient)
         val model = LlmClientFactory.resolveModel(config)
         KoogLlmCall(client, model)

--- a/shared/src/commonMain/kotlin/com/lumen/core/memory/IntentRetriever.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/core/memory/IntentRetriever.kt
@@ -1,6 +1,7 @@
 package com.lumen.core.memory
 
 import com.lumen.core.database.LumenDatabase
+import com.lumen.core.util.extractJsonObject
 import com.lumen.core.database.entities.MemoryEntry
 import com.lumen.core.database.entities.MemoryEntry_
 import kotlinx.coroutines.async
@@ -130,10 +131,4 @@ Decompose this into specific sub-queries for memory retrieval.
         }
     }
 
-    private fun extractJsonObject(text: String): String {
-        val start = text.indexOf('{')
-        val end = text.lastIndexOf('}')
-        if (start == -1 || end == -1 || end <= start) return "{}"
-        return text.substring(start, end + 1)
-    }
 }

--- a/shared/src/commonMain/kotlin/com/lumen/core/memory/SemanticSynthesizer.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/core/memory/SemanticSynthesizer.kt
@@ -1,6 +1,7 @@
 package com.lumen.core.memory
 
 import com.lumen.core.database.LumenDatabase
+import com.lumen.core.util.extractJsonObject
 import com.lumen.core.database.entities.MemoryEntry
 import com.lumen.core.database.entities.MemoryEntry_
 import kotlinx.serialization.json.Json
@@ -100,13 +101,6 @@ Decide: merge, update, or keep_both?
         } catch (_: Exception) {
             MergeDecision(action = "keep_both", reason = "Failed to parse LLM response")
         }
-    }
-
-    private fun extractJsonObject(text: String): String {
-        val start = text.indexOf('{')
-        val end = text.lastIndexOf('}')
-        if (start == -1 || end == -1 || end <= start) return "{}"
-        return text.substring(start, end + 1)
     }
 
     internal fun executeMerge(

--- a/shared/src/commonMain/kotlin/com/lumen/core/util/LlmResponseUtils.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/core/util/LlmResponseUtils.kt
@@ -1,0 +1,8 @@
+package com.lumen.core.util
+
+fun extractJsonObject(text: String): String {
+    val start = text.indexOf('{')
+    val end = text.lastIndexOf('}')
+    if (start == -1 || end == -1 || end <= start) return "{}"
+    return text.substring(start, end + 1)
+}

--- a/shared/src/commonMain/kotlin/com/lumen/research/analyzer/ArticleAnalyzer.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/research/analyzer/ArticleAnalyzer.kt
@@ -1,6 +1,7 @@
 package com.lumen.research.analyzer
 
 import com.lumen.core.database.LumenDatabase
+import com.lumen.core.util.extractJsonObject
 import com.lumen.core.database.entities.Article
 import com.lumen.core.memory.EmbeddingClient
 import com.lumen.core.memory.LlmCall
@@ -56,13 +57,6 @@ class ArticleAnalyzer(
         } catch (_: Exception) {
             "" to ""
         }
-    }
-
-    private fun extractJsonObject(text: String): String {
-        val start = text.indexOf('{')
-        val end = text.lastIndexOf('}')
-        if (start == -1 || end == -1 || end <= start) return "{}"
-        return text.substring(start, end + 1)
     }
 
     @Serializable

--- a/shared/src/commonMain/kotlin/com/lumen/research/analyzer/RelevanceScorer.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/research/analyzer/RelevanceScorer.kt
@@ -3,6 +3,7 @@ package com.lumen.research.analyzer
 import com.lumen.core.database.LumenDatabase
 import com.lumen.core.database.entities.Article
 import com.lumen.core.database.entities.ResearchProject
+import com.lumen.core.database.entities.ResearchProject_
 import com.lumen.core.memory.MemoryManager
 import com.lumen.core.memory.cosineSimilarity
 import com.lumen.research.parseCsvSet
@@ -15,7 +16,10 @@ class RelevanceScorer(
     suspend fun score(article: Article): Float {
         if (article.embedding.isEmpty()) return 0f
 
-        val activeProject = db.researchProjectBox.all.firstOrNull { it.isActive }
+        val activeProject = db.researchProjectBox.query()
+            .equal(ResearchProject_.isActive, true)
+            .build()
+            .use { it.findFirst() }
         val hasProject = activeProject != null && activeProject.embedding.isNotEmpty()
         val hasMemory = memoryManager != null
 
@@ -43,8 +47,8 @@ class RelevanceScorer(
     suspend fun scoreAndPersist(article: Article): Article {
         val relevanceScore = score(article)
         val updated = article.copy(aiRelevanceScore = relevanceScore)
-        db.articleBox.put(updated)
-        return db.articleBox.get(article.id)
+        val id = db.articleBox.put(updated)
+        return db.articleBox.get(id)
     }
 
     suspend fun scoreBatch(articles: List<Article>): List<Article> {

--- a/shared/src/commonMain/kotlin/com/lumen/research/collector/RssCollector.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/research/collector/RssCollector.kt
@@ -4,6 +4,7 @@ import com.lumen.core.database.LumenDatabase
 import com.lumen.core.database.entities.Article
 import com.lumen.core.database.entities.Article_
 import com.lumen.core.database.entities.Source
+import com.lumen.core.database.entities.Source_
 import com.prof18.rssparser.RssParser
 import com.prof18.rssparser.model.RssChannel
 import java.time.Instant
@@ -24,7 +25,10 @@ class RssCollector(
     }
 
     suspend fun fetchAll(): List<Article> {
-        val enabledSources = db.sourceBox.all.filter { it.enabled }
+        val enabledSources = db.sourceBox.query()
+            .equal(Source_.enabled, true)
+            .build()
+            .use { it.find() }
         return enabledSources.flatMap { source ->
             try {
                 fetchSource(source)
@@ -70,11 +74,10 @@ class RssCollector(
     }
 
     private fun queryExistingUrls(sourceId: Long): Set<String> {
-        val query = db.articleBox.query()
+        val articles = db.articleBox.query()
             .equal(Article_.sourceId, sourceId)
             .build()
-        val articles = query.find()
-        query.close()
+            .use { it.find() }
         return articles.mapTo(mutableSetOf()) { it.url }
     }
 

--- a/shared/src/commonMain/kotlin/com/lumen/research/digest/DigestGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/research/digest/DigestGenerator.kt
@@ -2,8 +2,12 @@ package com.lumen.research.digest
 
 import com.lumen.core.database.LumenDatabase
 import com.lumen.core.database.entities.Article
+import com.lumen.core.database.entities.Article_
 import com.lumen.core.database.entities.Digest
+import com.lumen.core.database.entities.Digest_
+import io.objectbox.query.QueryBuilder
 import com.lumen.core.memory.LlmCall
+import com.lumen.core.util.extractJsonObject
 import com.lumen.core.memory.MemoryManager
 import com.lumen.core.util.dateToEpochRange
 import com.lumen.research.parseCsvSet
@@ -50,13 +54,20 @@ class DigestGenerator(
     }
 
     private fun findExisting(date: String, projectId: Long): Digest? {
-        return db.digestBox.all.firstOrNull { it.date == date && it.projectId == projectId }
+        return db.digestBox.query()
+            .equal(Digest_.date, date, QueryBuilder.StringOrder.CASE_SENSITIVE)
+            .equal(Digest_.projectId, projectId)
+            .build()
+            .use { it.findFirst() }
     }
 
     internal fun collectArticles(date: String, projectId: Long): List<Article> {
         val (startOfDay, endOfDay) = dateToEpochRange(date)
-        return db.articleBox.all
-            .filter { it.fetchedAt in startOfDay until endOfDay }
+        val articles = db.articleBox.query()
+            .between(Article_.fetchedAt, startOfDay, endOfDay - 1)
+            .build()
+            .use { it.find() }
+        return articles
             .filter { it.aiSummary.isNotBlank() }
             .filter { projectId == 0L || projectId.toString() in parseCsvSet(it.projectIds) }
             .sortedByDescending { it.aiRelevanceScore }
@@ -82,7 +93,8 @@ class DigestGenerator(
 
         return try {
             val response = llmCall.execute(SYSTEM_PROMPT, userPrompt)
-            parseDigestResponse(response)
+            val parsed = parseDigestResponse(response)
+            if (parsed.first.isBlank()) buildFallbackDigest(topArticles, date) else parsed
         } catch (_: Exception) {
             buildFallbackDigest(topArticles, date)
         }
@@ -148,13 +160,6 @@ class DigestGenerator(
         } catch (_: Exception) {
             // Memory storage is best-effort
         }
-    }
-
-    private fun extractJsonObject(text: String): String {
-        val start = text.indexOf('{')
-        val end = text.lastIndexOf('}')
-        if (start == -1 || end == -1 || end <= start) return "{}"
-        return text.substring(start, end + 1)
     }
 
     @Serializable

--- a/shared/src/jvmMain/kotlin/com/lumen/research/collector/PlatformScheduler.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/lumen/research/collector/PlatformScheduler.jvm.kt
@@ -17,7 +17,6 @@ actual class PlatformScheduler(private val collectorManager: CollectorManager) {
         val newScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
         scope = newScope
         newScope.launch {
-            delay(intervalMillis)
             while (isActive) {
                 try {
                     collectorManager.runPipeline()


### PR DESCRIPTION
## Description

Comprehensive fix for bugs and code quality issues identified during M0-M2 implementation review. Addresses 4 bugs, 2 refactoring items, and 1 enhancement.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, code improvements)
- [x] Performance improvement

## Related Issues

- Closes #45
- Closes #46
- Closes #47
- Closes #48
- Closes #49
- Closes #50
- Closes #54

## Change List

- [x] Use put() return value in RelevanceScorer.scoreAndPersist() to prevent stale ID on new articles
- [x] Wrap ObjectBox query with .use{} in RssCollector.queryExistingUrls() to prevent resource leak
- [x] Remove initial delay in PlatformScheduler.jvm for immediate first pipeline run
- [x] Fall back to buildFallbackDigest() on empty LLM parse result in DigestGenerator
- [x] Extract duplicated extractJsonObject() into shared LlmResponseUtils
- [x] Replace 6 full-table scans with indexed ObjectBox queries
- [x] Add @Index on Digest.createdAt and Article.fetchedAt
- [x] Configure HttpTimeout (30s connect, 120s request) on all HttpClient instances

## Additional Notes

All existing tests pass. Schema change (new indexes) is backward-compatible — ObjectBox handles index addition transparently.