### PR TITLE
feat(ui): implement Chat UI with conversation management

### DIFF
--- a/shared/src/commonMain/kotlin/com/lumen/ui/screen/ChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/lumen/ui/screen/ChatScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -408,8 +409,11 @@ private fun ConversationChatScreen(
     var inputText by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }
     var typewriterTarget by remember { mutableStateOf("") }
+    var typewriterCounter by remember { mutableStateOf(0) }
     var typewriterDisplay by remember { mutableStateOf("") }
     var typewriterDone by remember { mutableStateOf(true) }
+    val agent = remember { agentFactory.get<LumenAgent>() }
+    DisposableEffect(Unit) { onDispose { agent.close() } }
 
     fun loadMessages() {
         conversation = conversationManager.getConversation(conversationId)
@@ -432,8 +436,8 @@ private fun ConversationChatScreen(
 
     LaunchedEffect(conversationId) { loadMessages() }
 
-    // Typewriter effect
-    LaunchedEffect(typewriterTarget) {
+    // Typewriter effect — counter key ensures re-trigger for duplicate responses
+    LaunchedEffect(typewriterTarget, typewriterCounter) {
         if (typewriterTarget.isEmpty()) return@LaunchedEffect
         typewriterDone = false
         typewriterDisplay = ""
@@ -464,7 +468,6 @@ private fun ConversationChatScreen(
         isLoading = true
 
         scope.launch {
-            val agent = agentFactory.get<LumenAgent>()
             try {
                 withContext(Dispatchers.Default) {
                     agent.chatStream(conversationId, text)
@@ -493,6 +496,7 @@ private fun ConversationChatScreen(
                             val msg = Message(role = "assistant", content = event.text)
                             uiItems.add(ChatUiItem.AssistantMessage(msg, ""))
                             typewriterTarget = event.text
+                            typewriterCounter++
                         }
                         is ChatEvent.MemoryExtracted -> {
                             uiItems.add(ChatUiItem.StatusInfo("Extracted ${event.count} memories"))
@@ -508,7 +512,6 @@ private fun ConversationChatScreen(
             } catch (e: Exception) {
                 snackbarHostState.showSnackbar(e.message ?: "Unknown error")
             } finally {
-                agent.close()
                 isLoading = false
             }
         }


### PR DESCRIPTION
## Description

Replace the placeholder ChatScreen with a full chat interface featuring conversation list, message display with tool call visualization, input field, progressive typewriter text display, and persona/project selectors.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

- Closes #61

## Change List

- [x] T1: State management with Compose state holders (conversations, messages, loading, etc.)
- [x] T2: Conversation list view with create/delete actions
- [x] T3: Chat message list with role-based bubble styling (user=primaryContainer, assistant=surfaceVariant)
- [x] T4: Typewriter effect for assistant responses (~20ms/char, tap to skip)
- [x] T5: Input bar with OutlinedTextField, send IconButton, CircularProgressIndicator
- [x] T6: Persona selector in new conversation dialog (dropdown with all available personas)
- [x] T7: Project selector in new conversation dialog (optional, ExposedDropdownMenuBox)
- [x] T8: Tool call visualization as collapsible cards with loading spinner
- [x] T9: Error handling via Snackbar (network errors, API key issues)
- [x] T10: Koin DI wiring (ConversationManager, PersonaManager, LumenAgent via koinInject/getKoin)

## Additional Notes

- Follows existing UI patterns from SettingsScreen and ArticlesScreen (koinInject, LaunchedEffect, remember, mutableStateOf)
- Uses `Icons.AutoMirrored.Filled.ArrowBack` for back navigation
- Memory recall/extraction events shown as centered status chips
- ChatUiItem sealed interface maps all ChatEvent types to UI representations
- No new test files (pure Compose UI, not testable with jvmTest; tested manually via compilation)