### PR TITLE
feat(server): add settings REST API with API key masking

### DIFF
--- a/server/src/main/kotlin/com/lumen/server/dto/SettingsDtos.kt
+++ b/server/src/main/kotlin/com/lumen/server/dto/SettingsDtos.kt
@@ -1,0 +1,59 @@
+package com.lumen.server.dto
+
+import com.lumen.core.config.AppConfig
+import com.lumen.core.config.LlmConfig
+import com.lumen.core.config.UserPreferences
+import kotlinx.serialization.Serializable
+
+private const val MASKED_KEY = "***"
+private const val MASK_PREFIX_LENGTH = 3
+
+@Serializable
+data class SettingsDto(
+    val llm: LlmConfigDto,
+    val preferences: UserPreferences,
+)
+
+@Serializable
+data class LlmConfigDto(
+    val provider: String,
+    val model: String,
+    val apiKey: String,
+    val apiBase: String,
+)
+
+@Serializable
+data class SettingsUpdateRequest(
+    val llm: LlmConfigDto,
+    val preferences: UserPreferences,
+)
+
+fun AppConfig.toSettingsDto(): SettingsDto = SettingsDto(
+    llm = LlmConfigDto(
+        provider = llm.provider,
+        model = llm.model,
+        apiKey = maskApiKey(llm.apiKey),
+        apiBase = llm.apiBase,
+    ),
+    preferences = preferences,
+)
+
+fun SettingsUpdateRequest.toAppConfig(existing: AppConfig): AppConfig = AppConfig(
+    llm = LlmConfig(
+        provider = llm.provider,
+        model = llm.model,
+        apiKey = if (isMaskedKey(llm.apiKey)) existing.llm.apiKey else llm.apiKey,
+        apiBase = llm.apiBase,
+    ),
+    preferences = preferences,
+)
+
+internal fun maskApiKey(key: String): String {
+    if (key.isBlank()) return ""
+    if (key.length <= MASK_PREFIX_LENGTH) return MASKED_KEY
+    return key.take(MASK_PREFIX_LENGTH) + MASKED_KEY
+}
+
+internal fun isMaskedKey(key: String): Boolean {
+    return key.isBlank() || key == MASKED_KEY || key.endsWith(MASKED_KEY)
+}

--- a/server/src/main/kotlin/com/lumen/server/routes/ApiRoutes.kt
+++ b/server/src/main/kotlin/com/lumen/server/routes/ApiRoutes.kt
@@ -14,9 +14,7 @@ fun Route.apiRoutes() {
             digestRoutes()
             chatRoutes()
             personaRoutes()
-            route("/settings") {
-                // #85: Settings REST API
-            }
+            settingsRoutes()
             route("/documents") {
                 // #86: Document Upload REST API
             }

--- a/server/src/main/kotlin/com/lumen/server/routes/SettingsRoutes.kt
+++ b/server/src/main/kotlin/com/lumen/server/routes/SettingsRoutes.kt
@@ -1,0 +1,32 @@
+package com.lumen.server.routes
+
+import com.lumen.core.config.ConfigStore
+import com.lumen.server.dto.SettingsUpdateRequest
+import com.lumen.server.dto.toAppConfig
+import com.lumen.server.dto.toSettingsDto
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import org.koin.ktor.ext.get as koinGet
+
+fun Route.settingsRoutes() {
+    route("/settings") {
+        get {
+            val configStore = call.application.koinGet<ConfigStore>()
+            val config = configStore.load()
+            call.respond(config.toSettingsDto())
+        }
+
+        put {
+            val configStore = call.application.koinGet<ConfigStore>()
+            val existing = configStore.load()
+            val request = call.receive<SettingsUpdateRequest>()
+            val updated = request.toAppConfig(existing)
+            configStore.save(updated)
+            call.respond(updated.toSettingsDto())
+        }
+    }
+}

--- a/server/src/test/kotlin/com/lumen/server/SettingsRoutesTest.kt
+++ b/server/src/test/kotlin/com/lumen/server/SettingsRoutesTest.kt
@@ -1,0 +1,276 @@
+package com.lumen.server
+
+import com.lumen.core.config.AppConfig
+import com.lumen.core.config.ConfigStore
+import com.lumen.core.config.LlmConfig
+import com.lumen.core.config.UserPreferences
+import com.lumen.server.dto.LlmConfigDto
+import com.lumen.server.dto.SettingsDto
+import com.lumen.server.dto.SettingsUpdateRequest
+import com.lumen.server.dto.isMaskedKey
+import com.lumen.server.dto.maskApiKey
+import com.lumen.server.plugins.AUTH_BEARER
+import com.lumen.server.plugins.configureAuth
+import com.lumen.server.plugins.configureErrorHandling
+import com.lumen.server.plugins.configureSerialization
+import com.lumen.server.routes.settingsRoutes
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.application.install
+import io.ktor.server.auth.authenticate
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.ktor.plugin.Koin
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SettingsRoutesTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val testToken = "test-token"
+
+    private lateinit var tempDir: File
+    private lateinit var configStore: ConfigStore
+
+    @BeforeTest
+    fun setup() {
+        tempDir = File(System.getProperty("java.io.tmpdir"), "lumen-settings-test-${System.nanoTime()}")
+        tempDir.mkdirs()
+        configStore = ConfigStore(tempDir)
+    }
+
+    @AfterTest
+    fun teardown() {
+        stopKoin()
+        tempDir.deleteRecursively()
+    }
+
+    private fun testKoinModule() = module {
+        single { configStore }
+    }
+
+    @Test
+    fun getSettings_returnsMaskedApiKey() = testApplication {
+        application {
+            configureSerialization()
+            configureErrorHandling()
+            configureAuth(testToken)
+            install(Koin) { modules(testKoinModule()) }
+            routing {
+                authenticate(AUTH_BEARER) {
+                    route("/api") { settingsRoutes() }
+                }
+            }
+        }
+
+        configStore.save(AppConfig(
+            llm = LlmConfig(provider = "deepseek", model = "deepseek-chat", apiKey = "sk-abc123xyz"),
+            preferences = UserPreferences(language = "en"),
+        ))
+
+        val response = client.get("/api/settings") {
+            bearerAuth(testToken)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.decodeFromString<SettingsDto>(response.bodyAsText())
+        assertEquals("deepseek", body.llm.provider)
+        assertEquals("deepseek-chat", body.llm.model)
+        assertEquals("sk-***", body.llm.apiKey)
+        assertEquals("en", body.preferences.language)
+    }
+
+    @Test
+    fun getSettings_emptyApiKey_returnsEmpty() = testApplication {
+        application {
+            configureSerialization()
+            configureErrorHandling()
+            configureAuth(testToken)
+            install(Koin) { modules(testKoinModule()) }
+            routing {
+                authenticate(AUTH_BEARER) {
+                    route("/api") { settingsRoutes() }
+                }
+            }
+        }
+
+        val response = client.get("/api/settings") {
+            bearerAuth(testToken)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.decodeFromString<SettingsDto>(response.bodyAsText())
+        assertEquals("", body.llm.apiKey)
+    }
+
+    @Test
+    fun putSettings_withMaskedKey_preservesExisting() = testApplication {
+        application {
+            configureSerialization()
+            configureErrorHandling()
+            configureAuth(testToken)
+            install(Koin) { modules(testKoinModule()) }
+            routing {
+                authenticate(AUTH_BEARER) {
+                    route("/api") { settingsRoutes() }
+                }
+            }
+        }
+
+        configStore.save(AppConfig(
+            llm = LlmConfig(provider = "deepseek", apiKey = "sk-real-secret-key"),
+        ))
+
+        val request = SettingsUpdateRequest(
+            llm = LlmConfigDto(
+                provider = "openai",
+                model = "gpt-4",
+                apiKey = "sk-***",
+                apiBase = "",
+            ),
+            preferences = UserPreferences(language = "en"),
+        )
+        val response = client.put("/api/settings") {
+            bearerAuth(testToken)
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(request))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val saved = configStore.load()
+        assertEquals("openai", saved.llm.provider)
+        assertEquals("gpt-4", saved.llm.model)
+        assertEquals("sk-real-secret-key", saved.llm.apiKey)
+        assertEquals("en", saved.preferences.language)
+    }
+
+    @Test
+    fun putSettings_withNewKey_updatesKey() = testApplication {
+        application {
+            configureSerialization()
+            configureErrorHandling()
+            configureAuth(testToken)
+            install(Koin) { modules(testKoinModule()) }
+            routing {
+                authenticate(AUTH_BEARER) {
+                    route("/api") { settingsRoutes() }
+                }
+            }
+        }
+
+        configStore.save(AppConfig(
+            llm = LlmConfig(apiKey = "old-key"),
+        ))
+
+        val request = SettingsUpdateRequest(
+            llm = LlmConfigDto(
+                provider = "deepseek",
+                model = "deepseek-chat",
+                apiKey = "sk-brand-new-key-12345",
+                apiBase = "",
+            ),
+            preferences = UserPreferences(),
+        )
+        val response = client.put("/api/settings") {
+            bearerAuth(testToken)
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(request))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val saved = configStore.load()
+        assertEquals("sk-brand-new-key-12345", saved.llm.apiKey)
+    }
+
+    @Test
+    fun putSettings_responseHasMaskedKey() = testApplication {
+        application {
+            configureSerialization()
+            configureErrorHandling()
+            configureAuth(testToken)
+            install(Koin) { modules(testKoinModule()) }
+            routing {
+                authenticate(AUTH_BEARER) {
+                    route("/api") { settingsRoutes() }
+                }
+            }
+        }
+
+        val request = SettingsUpdateRequest(
+            llm = LlmConfigDto(
+                provider = "deepseek",
+                model = "deepseek-chat",
+                apiKey = "sk-new-secret",
+                apiBase = "",
+            ),
+            preferences = UserPreferences(),
+        )
+        val response = client.put("/api/settings") {
+            bearerAuth(testToken)
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(request))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.decodeFromString<SettingsDto>(response.bodyAsText())
+        assertEquals("sk-***", body.llm.apiKey)
+    }
+
+    @Test
+    fun settings_withoutAuth_returns401() = testApplication {
+        application {
+            configureSerialization()
+            configureErrorHandling()
+            configureAuth(testToken)
+            install(Koin) { modules(testKoinModule()) }
+            routing {
+                authenticate(AUTH_BEARER) {
+                    route("/api") { settingsRoutes() }
+                }
+            }
+        }
+
+        val response = client.get("/api/settings")
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    // --- Unit tests for masking logic ---
+
+    @Test
+    fun maskApiKey_blankKey_returnsEmpty() {
+        assertEquals("", maskApiKey(""))
+        assertEquals("", maskApiKey("   "))
+    }
+
+    @Test
+    fun maskApiKey_shortKey_returnsFullMask() {
+        assertEquals("***", maskApiKey("ab"))
+        assertEquals("***", maskApiKey("abc"))
+    }
+
+    @Test
+    fun maskApiKey_normalKey_returnsPartialMask() {
+        assertEquals("sk-***", maskApiKey("sk-abc123"))
+    }
+
+    @Test
+    fun isMaskedKey_detectsMaskedValues() {
+        assertTrue(isMaskedKey(""))
+        assertTrue(isMaskedKey("***"))
+        assertTrue(isMaskedKey("sk-***"))
+        assertFalse(isMaskedKey("sk-real-key-123"))
+    }
+}


### PR DESCRIPTION
## Description

Expose user configuration reading and writing through REST API with secure API key handling.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

- Closes #85

## Change List

- [x] SettingsDtos.kt: DTOs with API key masking/preservation logic
- [x] SettingsRoutes.kt: GET /api/settings (masked response) and PUT /api/settings (key-preserving update)
- [x] ApiRoutes.kt: Wire in settingsRoutes() replacing placeholder
- [x] SettingsRoutesTest.kt: 10 tests covering masking, preservation, update, auth, and unit tests for mask logic

## Additional Notes

- API keys masked as `sk-***` (first 3 chars + `***`) in GET responses
- PUT with masked key value preserves existing key (detected via `endsWith("***")`)
- PUT with new key value updates the stored key
- PUT response also returns masked key to prevent leakage