### PR TITLE
fix: exclude integration tests in CI via Gradle filter

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -112,3 +112,11 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 }
+
+// Exclude network-dependent integration tests in CI
+tasks.withType<Test> {
+    if (System.getenv("CI") != null) {
+        exclude("**/RssDataSourceIntegrationTest*")
+        exclude("**/FeedFetchIntegrationTest*")
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/lumen/research/collector/FeedFetchIntegrationTest.kt
+++ b/shared/src/jvmTest/kotlin/com/lumen/research/collector/FeedFetchIntegrationTest.kt
@@ -7,26 +7,16 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import com.prof18.rssparser.RssParser
 import kotlinx.coroutines.runBlocking
-import org.junit.Assume.assumeTrue
-import org.junit.BeforeClass
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 /**
  * Integration tests that actually fetch from each configured feed.
  * These tests require network access and may fail if feeds are unreachable.
- * Skipped in CI (set CI=true to skip).
+ * Excluded from CI via Gradle filter.
  * Run manually to diagnose feed issues: ./gradlew :shared:jvmTest --tests "*.FeedFetchIntegrationTest"
  */
 class FeedFetchIntegrationTest {
-
-    companion object {
-        @JvmStatic
-        @BeforeClass
-        fun checkCi() {
-            assumeTrue("Skipping integration test in CI (no stable network)", System.getenv("CI") == null)
-        }
-    }
 
     private val httpClient = HttpClient(CIO) {
         engine {

--- a/shared/src/jvmTest/kotlin/com/lumen/research/collector/RssDataSourceIntegrationTest.kt
+++ b/shared/src/jvmTest/kotlin/com/lumen/research/collector/RssDataSourceIntegrationTest.kt
@@ -4,7 +4,6 @@ import com.lumen.core.database.LumenDatabase
 import com.lumen.core.database.entities.MyObjectBox
 import com.lumen.core.database.entities.Source
 import kotlinx.coroutines.runBlocking
-import org.junit.Assume.assumeTrue
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -16,7 +15,7 @@ import kotlin.test.assertTrue
  * Tests the FULL flow: fetch RSS XML -> parse via RssParser -> processChannel -> persist to DB.
  * This catches issues that raw HTTP tests miss (e.g., parser failures, empty items, null links).
  *
- * Requires network access; skipped in CI (set CI=true to skip).
+ * Requires network access; excluded from CI via Gradle filter.
  * Run manually: ./gradlew :shared:jvmTest --tests "*.RssDataSourceIntegrationTest"
  */
 class RssDataSourceIntegrationTest {
@@ -27,7 +26,6 @@ class RssDataSourceIntegrationTest {
 
     @BeforeTest
     fun setup() {
-        assumeTrue("Skipping integration test in CI (no stable network)", System.getenv("CI") == null)
         tempDir = File(System.getProperty("java.io.tmpdir"), "objectbox-rss-integ-${System.nanoTime()}")
         tempDir.mkdirs()
         val store = MyObjectBox.builder().baseDirectory(tempDir).build()


### PR DESCRIPTION
## Description

Fix CI test failures by properly excluding network-dependent integration tests using Gradle's `tasks.withType<Test>` filter instead of JUnit Assume (which is incompatible with kotlin.test's JUnit 5 mapping).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Configuration/Build changes

## Change List

- [x] Add Gradle test exclusion in `shared/build.gradle.kts` when `CI` env var is set
- [x] Revert JUnit Assume imports (incompatible with JUnit 5)
- [x] Grant `contents: write` permission to release workflow

## Additional Notes

- Previous fix using `org.junit.Assume.assumeTrue` caused `TestCouldNotBeSkippedException` because kotlin.test on JVM uses JUnit 5, not JUnit 4
- Gradle-level exclusion is the most reliable cross-framework approach